### PR TITLE
fix: improve init container helm post checks SYS-725

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+: ${IMG_TAG:="latest"}
+
 docker buildx build \
   --platform linux/amd64 \
-  --tag intellum/k8s-wait-for:latest \
+  --tag intellum/k8s-wait-for:${IMG_TAG} \
   --push \
   .

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -170,12 +170,14 @@ get_job_state() {
         else
           echo "$get_job_state_output" >&2
         fi
+        echo true
         return
     elif [ $DEBUG -ge 2 ]; then
         echo "$get_job_state_output" >&2
     fi
     if [ -z "$get_job_state_output" ] || echo "$get_job_state_output" | grep -q "No resources found"; then
         echo "wait_for.sh: No jobs found!" >&2
+        echo true
         return
     fi
 
@@ -185,6 +187,7 @@ get_job_state() {
     if [ $? -ne 0 ]; then
         echo "$get_job_state_output" >&2
         echo "$get_job_state_output1" >&2
+        echo true
         return
     elif [ $DEBUG -ge 2 ]; then
         echo "${get_job_state_output1}" >&2

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -8,7 +8,7 @@ trap "exit 1" TERM
 TOP_PID=$$
 
 KUBECTL_ARGS=""
-WAIT_TIME="${WAIT_TIME:-2}" # seconds
+WAIT_TIME="${WAIT_TIME:-10}" # seconds
 DEBUG="${DEBUG:-0}"
 TREAT_ERRORS_AS_READY="${TREAT_ERRORS_AS_READY:-0}"
 
@@ -165,13 +165,13 @@ get_job_state() {
 
     if [ $? -ne 0 ]; then
         echo "$get_job_state_output" >&2
-        kill -s TERM $TOP_PID
+        return
     elif [ $DEBUG -ge 2 ]; then
         echo "$get_job_state_output" >&2
     fi
     if [ -z "$get_job_state_output" ] || echo "$get_job_state_output" | grep -q "No resources found"; then
         echo "wait_for.sh: No jobs found!" >&2
-        kill -s TERM $TOP_PID
+        return
     fi
 
     # Extract number of <avtive>:<ready>:<succeeded>:<failed>
@@ -180,7 +180,7 @@ get_job_state() {
     if [ $? -ne 0 ]; then
         echo "$get_job_state_output" >&2
         echo "$get_job_state_output1" >&2
-        kill -s TERM $TOP_PID
+        return
     elif [ $DEBUG -ge 2 ]; then
         echo "${get_job_state_output1}" >&2
     fi

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -164,7 +164,12 @@ get_job_state() {
     get_job_state_output=$(kubectl describe jobs "$get_job_state_name" $KUBECTL_ARGS 2>&1)
 
     if [ $? -ne 0 ]; then
-        echo "$get_job_state_output" >&2
+        if echo "$get_job_state_output" | grep -q "NotFound"; then
+          timestamp=$(date +'%Y-%m-%d %H:%M:%S')
+          echo "[$timestamp] job $get_job_state_name not found..." >&2
+        else
+          echo "$get_job_state_output" >&2
+        fi
         return
     elif [ $DEBUG -ge 2 ]; then
         echo "$get_job_state_output" >&2


### PR DESCRIPTION
[SYS-725](https://intellum.atlassian.net/browse/SYS-725)

use while loop condition instead of crashloopbackoff. this keeps the init-container running while waiting for job completion, instead of killing the container and relying on the restart policy for subsequent job completion status checks.

[SYS-725]: https://intellum.atlassian.net/browse/SYS-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ